### PR TITLE
refactor: scene-stats-container 避免全屏显示

### DIFF
--- a/src/vue-app/views/SceneView.vue
+++ b/src/vue-app/views/SceneView.vue
@@ -811,8 +811,6 @@ onUnmounted(() => {
   position: absolute;
   top: calc(var(--toolbar-height) + var(--toolbar-spacing));
   left: 0;
-  width: 100%;
-  height: 100%;
   z-index: 10;
   pointer-events: none;
   overflow: visible;


### PR DESCRIPTION
## 修改内容
- 移除 `.scene-stats-container` 的 `width: 100%` 和 `height: 100%`
- 让 Stats 工具只占用必要的空间，而不是全屏容器

🤖 Generated with [Claude Code](https://claude.com/claude-code)